### PR TITLE
Fix for php8.4

### DIFF
--- a/phpstan-bootstrap-mage-autoload.php
+++ b/phpstan-bootstrap-mage-autoload.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 use PHPStanMagento1\Autoload\Magento\ModuleControllerAutoloader;
 
 /**
- * @var $container \PHPStan\DependencyInjection\MemoizingContainer
+ * @var \PHPStan\DependencyInjection\MemoizingContainer $container
  */
 $magentoRootPath = $container->getParameter('magentoRootPath');
 if (empty($magentoRootPath)) {
@@ -23,11 +24,11 @@ if (!defined('BP')) {
  * We replace the original Varien_Autoload autoloader with a custom one in order to prevent errors with invalid classes
  * that are used throughout the Magento core code.
  * The original autoloader would in this case return false and lead to an error in phpstan because the type alias in extension.neon
- * is evaluated afterwards.
+ * is evaluated afterward.
  *
  * @see \Varien_Autoload::autoload()
  */
-spl_autoload_register(static function($className) {
+spl_autoload_register(static function ($className) {
     spl_autoload_unregister([Varien_Autoload::instance(), 'autoload']);
 
     $classFile = str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $className)));

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 use PHPStanMagento1\Autoload\Magento\ModuleControllerAutoloader;
 
 /**
- * @var $container \PHPStan\DependencyInjection\MemoizingContainer
+ * @var \PHPStan\DependencyInjection\MemoizingContainer $container
  */
 $magentoRootPath = $container->getParameter('magentoRootPath');
 if (empty($magentoRootPath)) {
@@ -35,7 +36,7 @@ $paths[] = BP . DS . 'lib';
 
 $appPath = implode(PS, $paths);
 set_include_path($appPath . PS . get_include_path());
-include_once "Mage/Core/functions.php";
+include_once 'Mage/Core/functions.php';
 
 (new ModuleControllerAutoloader('local'))->register();
 (new ModuleControllerAutoloader('core'))->register();
@@ -46,8 +47,7 @@ include_once "Mage/Core/functions.php";
  * Autoloading is needed only for the PHPStanMagento1\Config\MagentoCore which inherits from some magento classes.
  * PHPStan uses static analysis, so doesn't require autoloading.
  */
-spl_autoload_register(static function($className) {
-
+spl_autoload_register(static function ($className) {
     $classFile = str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $className)));
     $classFile .= '.php';
 

--- a/src/Autoload/Magento/ModuleControllerAutoloader.php
+++ b/src/Autoload/Magento/ModuleControllerAutoloader.php
@@ -15,7 +15,7 @@ final class ModuleControllerAutoloader
     /** @var string */
     private $codePool;
 
-    public function __construct(string $codePool, string $magentoRoot = null)
+    public function __construct(string $codePool, ?string $magentoRoot = null)
     {
         if (empty($magentoRoot)) {
             $magentoRoot = BP;

--- a/src/Config/MagentoCore.php
+++ b/src/Config/MagentoCore.php
@@ -531,7 +531,7 @@ class MagentoCore extends \Mage_Core_Model_Config_Base
      */
     protected function _makeEventsLowerCase($area, \Varien_Simplexml_Config $mergeModel)
     {
-        $events = $mergeModel->getNode($area . "/" . \Mage_Core_Model_App_Area::PART_EVENTS);
+        $events = $mergeModel->getNode($area . '/' . \Mage_Core_Model_App_Area::PART_EVENTS);
         if ($events !== false) {
             $children = clone $events->children();
             /** @var \Mage_Core_Model_Config_Element $event */


### PR DESCRIPTION
> PHP Deprecated:  PHPStanMagento1\Autoload\Magento\ModuleControllerAutoloader::__construct(): Implicitly marking parameter $magentoRoot as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/magento-lts/magento-lts/vendor/macopedia/phpstan-magento1/src/Autoload/Magento/ModuleControllerAutoloader.php on line 18